### PR TITLE
Restructure data entry for all routes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "valence_core"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT"
 keywords = ["blockchain", "L2", "peer-to-peer", "P2P"]

--- a/src/api/utils.rs
+++ b/src/api/utils.rs
@@ -47,7 +47,7 @@ pub fn get_cors() -> warp::cors::Builder {
 }
 
 /// Easy and simple DELETE CORS
-pub fn delete_cors() -> warp::cors::Builder {
+pub fn del_cors() -> warp::cors::Builder {
     cors_builder(vec!["DELETE", "OPTIONS"])
 }
 

--- a/src/db/handler.rs
+++ b/src/db/handler.rs
@@ -50,7 +50,7 @@ pub trait KvStoreConnection {
     ///
     /// * `key` - Key of the data entry to delete
     /// * `value_id` - ID of the value to delete. If not provided, all values for the key are deleted
-    async fn delete_data(
+    async fn del_data(
         &mut self,
         key: &str,
         value_id: Option<&str>,

--- a/src/db/handler.rs
+++ b/src/db/handler.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
+use std::collections::HashMap;
 
 /// Trait for a key-value data store connection
 #[async_trait]
@@ -18,10 +19,12 @@ pub trait KvStoreConnection {
     /// ### Arguments
     ///
     /// * `key` - Key of the data entry to set
+    /// * `value_id` - ID of the value to set
     /// * `value` - Value of the data entry to set
     async fn set_data<T: Serialize + Send + DeserializeOwned>(
         &mut self,
         key: &str,
+        value_id: &str,
         value: T,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
@@ -30,11 +33,13 @@ pub trait KvStoreConnection {
     /// ### Arguments
     ///
     /// * `key` - Key of the data entry to set
+    /// * `value_id` - ID of the value to set
     /// * `value` - Value of the data entry to set
     /// * `seconds` - Number of seconds to expire the data entry in
     async fn set_data_with_expiry<T: Serialize + DeserializeOwned + Send>(
         &mut self,
         key: &str,
+        value_id: &str,
         value: T,
         seconds: usize,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
@@ -44,9 +49,11 @@ pub trait KvStoreConnection {
     /// ### Arguments
     ///
     /// * `key` - Key of the data entry to delete
+    /// * `value_id` - ID of the value to delete. If not provided, all values for the key are deleted
     async fn delete_data(
         &mut self,
         key: &str,
+        value_id: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
     /// Gets a data entry from the cache
@@ -54,10 +61,12 @@ pub trait KvStoreConnection {
     /// ### Arguments
     ///
     /// * `key` - Key of the data entry to get
-    async fn get_data<T: DeserializeOwned>(
+    /// * `value_id` - ID of the value to get. If not provided, all values for the key are retrieved
+    async fn get_data<T: Clone + DeserializeOwned>(
         &mut self,
         key: &str,
-    ) -> Result<Option<Vec<T>>, Box<dyn std::error::Error + Send + Sync>>;
+        value_id: Option<&str>,
+    ) -> Result<Option<HashMap<String, T>>, Box<dyn std::error::Error + Send + Sync>>;
 }
 
 #[async_trait]

--- a/src/db/mongo_db.rs
+++ b/src/db/mongo_db.rs
@@ -193,13 +193,13 @@ impl KvStoreConnection for MongoDbConn {
         Ok(())
     }
 
-    async fn delete_data(
+    async fn del_data(
         &mut self,
         key: &str,
         value_id: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // Tracing
-        let span = span!(Level::TRACE, "MongoDbConn::delete_data");
+        let span = span!(Level::TRACE, "MongoDbConn::del_data");
         let _enter = span.enter();
 
         let collection = self

--- a/src/db/redis_cache.rs
+++ b/src/db/redis_cache.rs
@@ -1,7 +1,10 @@
+use std::collections::HashMap;
+
 use crate::db::handler::{CacheHandler, KvStoreConnection};
 use async_trait::async_trait;
 use redis::{aio::ConnectionManager, AsyncCommands};
 use serde::{de::DeserializeOwned, Serialize};
+use tracing::{event, span, Level};
 
 #[derive(Clone)]
 pub struct RedisCacheConn {
@@ -34,22 +37,23 @@ impl KvStoreConnection for RedisCacheConn {
     async fn set_data<T: Serialize + DeserializeOwned + Send>(
         &mut self,
         key: &str,
+        value_id: &str,
         value: T,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let exists: bool = self.connection.exists(key).await?;
 
-        let mut vec: Vec<T> = if exists {
+        let mut mapping: HashMap<String, T> = if exists {
             // Get the existing data
             let data: String = self.connection.get(key).await?;
             serde_json::from_str(&data)?
         } else {
-            Vec::new()
+            HashMap::new()
         };
 
         // Append the new data to the vec
-        vec.push(value);
+        mapping.insert(value_id.to_string(), value);
 
-        let serialized = serde_json::to_string(&vec)?;
+        let serialized = serde_json::to_string(&mapping)?;
         self.connection.set(key, serialized).await?;
 
         Ok(())
@@ -58,25 +62,26 @@ impl KvStoreConnection for RedisCacheConn {
     async fn set_data_with_expiry<T: Serialize + DeserializeOwned + Send>(
         &mut self,
         key: &str,
+        value_id: &str,
         value: T,
         seconds: usize,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // Check if the key exists
         let exists: bool = self.connection.exists(key).await?;
 
-        let mut vec: Vec<T> = if exists {
+        let mut mapping: HashMap<String, T> = if exists {
             // Get the existing data
             let data: String = self.connection.get(key).await?;
             serde_json::from_str(&data)?
         } else {
-            Vec::new()
+            HashMap::new()
         };
 
-        // Append the new data to the vec
-        vec.push(value);
+        // Append the new data to the hashmap
+        mapping.insert(value_id.to_string(), value);
 
         // Serialize the vec back to a string
-        let serialized = serde_json::to_string(&vec)?;
+        let serialized = serde_json::to_string(&mapping)?;
 
         // Set the data back to Redis
         self.connection.set(key, serialized).await?;
@@ -90,23 +95,57 @@ impl KvStoreConnection for RedisCacheConn {
     async fn delete_data(
         &mut self,
         key: &str,
+        value_id: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(value_id) = value_id {
+            let exists: bool = self.connection.exists(key).await?;
+
+            if exists {
+                let mut mapping: HashMap<String, String> = self.get_data(key, None).await?.unwrap();
+                mapping.remove(value_id);
+                let serialized = serde_json::to_string(&mapping)?;
+                self.connection.set(key, serialized).await?;
+            }
+            return Ok(());
+        }
+
         let _: () = self.connection.del(key).await?;
         Ok(())
     }
 
-    async fn get_data<T: DeserializeOwned>(
+    async fn get_data<T: Clone + DeserializeOwned>(
         &mut self,
         key: &str,
-    ) -> Result<Option<Vec<T>>, Box<dyn std::error::Error + Send + Sync>> {
+        value_id: Option<&str>,
+    ) -> Result<Option<HashMap<String, T>>, Box<dyn std::error::Error + Send + Sync>> {
+        let span = span!(Level::TRACE, "MongoDbConn::get_data");
+        let _enter = span.enter();
+
         // Check if the key exists
         let exists: bool = self.connection.exists(key).await?;
 
         if exists {
             // Get the existing data
             let data: String = self.connection.get(key).await?;
-            let vec: Vec<T> = serde_json::from_str(&data)?;
-            return Ok(Some(vec));
+            let mapping: HashMap<String, T> = serde_json::from_str(&data)?;
+
+            if let Some(value_id) = value_id {
+                let value = mapping.get(value_id);
+                if let Some(value) = value {
+                    let mut new_mapping: HashMap<String, T> = HashMap::new();
+                    new_mapping.insert(value_id.to_string(), value.clone());
+                    return Ok(Some(new_mapping));
+                } else {
+                    // Value with the given ID not found
+                    event!(
+                        Level::ERROR,
+                        "Value with ID {value_id} not found for key {key}"
+                    );
+                    return Ok(None);
+                }
+            }
+
+            return Ok(Some(mapping));
         }
 
         Ok(None)

--- a/src/db/redis_cache.rs
+++ b/src/db/redis_cache.rs
@@ -92,7 +92,7 @@ impl KvStoreConnection for RedisCacheConn {
         Ok(())
     }
 
-    async fn delete_data(
+    async fn del_data(
         &mut self,
         key: &str,
         value_id: Option<&str>,


### PR DESCRIPTION
## Description
Restructures the data entry for all available routes, now requiring an ID for each value saved to disk

## Changelog

- Changes all `delete_data` routes to `del_data`
- Adds `value_id` to `set_data`, `get_data` and `del_data` routes
- Data entries are now saved as hash maps instead of vectors

## Type of Change
Please mark the appropriate option by putting an "x" inside the brackets:

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement or optimization
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist
Put an "x" in the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have tested the changes locally and they work as expected.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] My code follows the project's coding standards and style guidelines.
- [x] I have added/updated relevant tests to ensure the changes are properly covered.
- [x] I have checked for and resolved any merge conflicts.
- [x] My commits have clear and descriptive messages.